### PR TITLE
Update yolo_example.py

### DIFF
--- a/py_examples/yolo_example.py
+++ b/py_examples/yolo_example.py
@@ -119,7 +119,7 @@ if len(devices) == 0:
 	quit()
 device = mvnc.Device(devices[0])
 device.OpenDevice()
-opt = device.GetDeviceOption(mvnc.DeviceOption.OPTIMISATION_LIST)
+# opt = device.GetDeviceOption(mvnc.DeviceOption.OPTIMISATION_LIST) # opt is not used
 # load blob
 with open(network_blob, mode='rb') as f:
 	blob = f.read()


### PR DESCRIPTION
`opt` is not used and this line runs into an error on my side. Commenting this line out fixed the issue and everything is working neatly. Thank you for this great framework!

The output I get when running ` python py_examples/yolo_example.py images/dog.jpg`:

	Found stale device, resetting
	Device 0 Address: 1.4 - VID/PID 03e7:2150
	Starting wait for connect with 2000ms timeout
	Found Address: 1.4 - VID/PID 03e7:2150
	Found EP 0x81 : max packet size is 512 bytes
	Found EP 0x01 : max packet size is 512 bytes
	Found and opened device
	Performing bulk write of 830212 bytes...
	Successfully sent 830212 bytes of data in 129.376644 ms (6.119743 MB/s)
	Boot successful, device address 1.4
	Found Address: 1.4 - VID/PID 03e7:f63b
	done
	Booted 1.4 -> VSC
	Traceback (most recent call last):
	  File "py_examples/yolo_example.py", line 122, in <module>
	    opt = device.GetDeviceOption(mvnc.DeviceOption.OPTIMISATION_LIST)
	  File "/usr/local/lib/python2.7/dist-packages/mvnc/mvncapi.py", line 190, in GetDeviceOption
	    end = ss.find(0)
	TypeError: expected a string or other character buffer object
